### PR TITLE
Fuzzpool

### DIFF
--- a/Test/FuzzCheck/Pool.hs
+++ b/Test/FuzzCheck/Pool.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE TupleSections #-}
+
+module Test.FuzzCheck.Pool where
+
+import Control.Applicative
+import Control.Monad (unless, void)
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Control
+import Data.IORef
+import Data.Traversable (forM)
+import Data.Typeable
+import GHC.Prim (Any)
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as MV
+import Test.QuickCheck
+import Unsafe.Coerce
+
+import Test.FuzzCheck
+
+data PoolAction (m :: * -> *) = forall a. PoolTaggable m a => PoolAction a
+
+data PoolTag (m :: * -> *) = PoolTag [TypeRep] TypeRep
+
+class PoolTaggable m a where
+    poolTag :: a -> PoolTag m
+
+instance (Typeable a) => PoolTaggable m (m a) where
+    poolTag _ = PoolTag [] $ typeOf (undefined :: a)
+
+instance (Typeable a, PoolTaggable m b) => PoolTaggable m (a -> b) where
+    poolTag _ = PoolTag (typeOf (undefined :: a) : xs) r
+      where
+        PoolTag xs r = poolTag (undefined :: b) :: PoolTag m
+
+{- NOTE: could instead use this + runtime exceptions
+splitTyArrows :: TypeRep -> [TypeRep]
+splitTyArrows t =
+    case splitTyConApp t of
+        (tc, [tl, tr]) | tc == funTc -> tl : splitTyArrows tr
+        _ -> [t]
+-}
+
+fuzzPool :: forall m. (MonadIO m, MonadBaseControl IO m)
+         => Int -> Int -> [PoolAction m] -> m ()
+fuzzPool runs poolSize actions = do
+    let tagged = map (\x@(PoolAction a) -> (poolTag a :: PoolTag m, x)) actions
+        inputs = S.fromList $ concatMap (\(PoolTag inTys _, _) -> inTys) tagged
+        outputs = S.fromList $ map (\(PoolTag _ outTy, _) -> outTy) tagged
+
+    -- Warn about inputs and outputs that won't be used.
+    -- (NOTE: doesn't compute actual reachability)
+    let unreachableInputs = S.difference inputs outputs
+        unreachableOutputs = S.difference outputs (S.insert (typeOf ()) inputs)
+    unless (S.null unreachableInputs) $ liftIO $ do
+        putStrLn "Warning: The following FuzzPool input types are unreachable:"
+        print $ S.toList unreachableInputs
+    unless (S.null unreachableOutputs) $ liftIO $ do
+        putStrLn "Warning: The following FuzzPool output types are unused:"
+        print $ S.toList unreachableOutputs
+
+    -- Fuzzify!
+    pools <- liftIO . mapM initPool . S.toList
+           $ S.difference inputs unreachableInputs
+
+    go (V.fromList tagged) (M.fromList pools) 0
+  where
+    initPool k = do
+      pool <- liftIO $ MV.new poolSize
+      size <- newIORef 0
+      return (k, (size, pool))
+
+    go :: V.Vector (PoolTag m, PoolAction m)
+       -> M.Map TypeRep (IORef Int, MV.IOVector Any)
+       -> Int
+       -> m ()
+    go tagged pools i
+        | i >= runs = return ()
+        | otherwise = do
+            let len = V.length tagged
+            n <- "pick a random action"
+              ?> return <$> gen (choose (0,len-1) :: Gen Int)
+            case V.unsafeIndex tagged n of
+                (PoolTag inTys outTy, PoolAction f) -> do
+                    -- Pick values from pools that match the argument types.
+                    mvals <- sequence <$> mapM pickValue inTys
+                    -- If we got values for all of the arguments, apply them.
+                    outVal <- forM mvals $ unsafeCoerce . foldl unsafeCoerce f
+                    -- Store the result value.
+                    _ <- forM outVal (storeValue outTy)
+                    return ()
+            go tagged pools (i + 1)
+      where
+        pickValue :: TypeRep -> m (Maybe Any)
+        pickValue ty =
+            case M.lookup ty pools of
+                Nothing -> return Nothing
+                Just (sizeRef, pool) -> do
+                    size <- liftIO $ readIORef sizeRef
+                    if size == 0
+                        then return Nothing
+                        else do
+                            n <- ("pick from pool a value of type " ++ show ty)
+                              ?> return <$> gen (choose (0,size-1) :: Gen Int)
+                            Just <$> liftIO (MV.unsafeRead pool n)
+        storeValue :: TypeRep -> Any -> m ()
+        storeValue ty val =
+            void $ forM (M.lookup ty pools) $ \(sizeRef, pool) -> do
+                size <- liftIO $ readIORef sizeRef
+                if size >= poolSize
+                    then liftIO $ do
+                        n <- ("replace a random value in pool for " ++ show ty)
+                          ?> return <$> gen (choose (0,size-1) :: Gen Int)
+                        MV.write pool n val
+                    else liftIO $ do
+                        MV.write pool size val
+                        writeIORef sizeRef (size + 1)

--- a/fuzzcheck.cabal
+++ b/fuzzcheck.cabal
@@ -36,9 +36,13 @@ Library
     Ghc-options:      -Wall
     Default-language: Haskell2010
     Exposed-modules:  Test.FuzzCheck
+                      Test.FuzzCheck.Pool
     Build-depends:    base
                     , monad-control
                     , lifted-base
                     , transformers
                     , random
                     , QuickCheck
+                    , vector
+                    , containers
+                    , ghc-prim

--- a/tests/Smoke.hs
+++ b/tests/Smoke.hs
@@ -45,4 +45,5 @@ main = hspec $ do
 
     err = "FuzzException \"qc1 \\\"3\\\": user error (x divisible by three!)\""
 
-    fuzzCheckFAIL msg f = f `shouldThrow` \(e :: FuzzException) -> show e == msg
+    fuzzCheckFAIL msg f = fuzzCheck f `shouldThrow`
+        \(e :: FuzzException) -> show e == msg

--- a/tests/SmokePool.hs
+++ b/tests/SmokePool.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Control.Applicative
+import Control.Monad
+import Test.FuzzCheck
+import Test.FuzzCheck.Pool
+import Test.Hspec
+import Test.HUnit
+import Test.QuickCheck
+
+main :: IO ()
+main = hspec $ do
+    itio "works with a test with only one value pool" $
+        fuzzPool 100 10
+            [ PoolAction ((\x -> assertBool "greater" (x > 0)) :: Int -> IO ())
+            , PoolAction (return 2 :: IO Int)
+            , PoolAction (return . (*2) :: Int -> IO Int)
+            ]
+
+    itio "works with a test with multiple pools" $
+        fuzzPool 100 10
+            [ PoolAction (\i -> return . concat . replicate i :: String -> IO String)
+            , PoolAction (return 3 :: IO Int)
+            , PoolAction (return "hello! " :: IO String)
+            ]
+
+    itio "doesn't execute unreachable tests" $
+        fuzzPool 100 10
+            [ PoolAction (const $ assertFailure "failure" :: Bool -> IO ())
+            , PoolAction (return 3 :: IO Int)
+            ]
+
+    itio "fails for a failing test" $
+        fuzzPoolFAIL ""
+            [ PoolAction ("fail" ?> pure (ioError $ userError "test") :: IO ())
+            , PoolAction (return 0 :: IO Int)
+            ]
+
+  where
+    itio msg f = it msg (f :: IO ())
+
+    fuzzPoolFAIL msg fs = fuzzPool 100 10 fs `shouldThrow`
+        \(e :: FuzzException) -> True -- show e == msg


### PR DESCRIPTION
Hey @jwiegley!

Here's an initial swing at the fuzz pool stuff.  I'm not sure if this implementation is the way to go.  In particular, it seems iffy to use typeclasses for the variadic stuff (IncoherentInstances, blech).

Also, maybe "SmokePool" would be merged into "Smoke", to avoid another test-suite in the cabal file.  Also, it's a bit annoying that this makes it non-portable (ghc-prim).  Maybe it ought to be a different library.

Finally, I'm not sure how reproducing a test run would work.  Sure, there's the random seed, but it'd be nice to be able to store reproducing cases even when the test changes, maybe by generating code.  That would imply a TH implementation strategy rather than using typeable / pools..
